### PR TITLE
Oauth support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-cwltool==1.0.20180912090223
+cwltool>=1.0.20181201184214
 future>=0.16.0
 requests>=2.18.2
-py-tes>=0.2.1
+py-tes>=0.3.0
+PyJWT>=1.6.4
 typing_extensions

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         "cwltool>=1.0.20180921163344",
         "future>=0.16.0",
         "py-tes>=0.2.0",
+        "PyJWT>=1.6.4",
         "requests>=2.14.2",
         "typing_extensions"
     ],

--- a/setup.py
+++ b/setup.py
@@ -40,16 +40,16 @@ setup(
     packages=find_packages(),
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4",
     install_requires=[
-        "cwltool>=1.0.20180921163344",
+        "cwltool>=1.0.20181201184214",
         "future>=0.16.0",
-        "py-tes>=0.2.0",
+        "py-tes>=0.3.0",
         "PyJWT>=1.6.4",
         "requests>=2.14.2",
         "typing_extensions"
     ],
     extras_require={
         "test": [
-            "cwltest>=1.0.20180601100346",
+            "cwltool>=1.0.20181201184214",
             "nose>=1.3.7",
             "flake8>=3.5.0",
             "PyYAML>=3.12"


### PR DESCRIPTION
This PR adds `--token` and `--token-public-key` to pass OAuth2 Bearer tokens to the TES endpoint. The token is validated via the public key.

This PR replaces #27 by @juhtornr (which was unfortunately never merged). The differences between #27 and this PR are:
- the new version is based on the latest/current version of `cwl-tes` `master`, so there will be no merge conflicts
- it does _not_ include a default public key
- it bumps the versions of `cwltool` and `py-tes` to some newer versions

The suggested changes have been successfully tested in https://github.com/elixir-europe/WES-ELIXIR and this merge would help us immensely because we wouldn't have to keep up maintaining a fork.