### PR TITLE
FTP has issues with username & password on non-secure protocol

### DIFF
--- a/cwl_tes/ftp.py
+++ b/cwl_tes/ftp.py
@@ -36,10 +36,11 @@ def abspath(src, basedir):  # type: (Text, Text) -> Text
 
 class FtpFsAccess(StdFsAccess):
     """FTP access with upload."""
-    def __init__(self, basedir, cache=None):  # type: (Text) -> None
+    def __init__(self, basedir, cache=None, insecure=False):  # type: (Text) -> None
         super(FtpFsAccess, self).__init__(basedir)
         self.cache = cache or {}
         self.netrc = None
+        self.insecure = insecure
         try:
             if 'HOME' in os.environ:
                 if os.path.exists(os.path.join(os.environ['HOME'], '.netrc')):
@@ -81,7 +82,7 @@ class FtpFsAccess(StdFsAccess):
             ftp = ftplib.FTP_TLS()
             ftp.set_debuglevel(1 if _logger.isEnabledFor(logging.DEBUG) else 0)
             ftp.connect(host)
-            ftp.login(user, passwd)
+            ftp.login(user, passwd, secure=not self.insecure)
             self.cache[(host, user, passwd)] = ftp
             return ftp
         return None

--- a/cwl_tes/ftp.py
+++ b/cwl_tes/ftp.py
@@ -55,7 +55,7 @@ class FtpFsAccess(StdFsAccess):
         parse = urllib.parse.urlparse(url)
         user = parse.username
         passwd = parse.password
-        host = parse.netloc
+        host = parse.hostname
         path = parse.path
         if parse.scheme == 'ftp':
             if not user and self.netrc:

--- a/cwl_tes/ftp.py
+++ b/cwl_tes/ftp.py
@@ -189,8 +189,13 @@ class FtpFsAccess(StdFsAccess):
     def listdir(self, fn):  # type: (Text) -> List[Text]
         ftp = self._connect(fn)
         if ftp:
-            host, _, _, path = self._parse_url(fn)
-            return ["ftp://{}/{}".format(host, x) for x in ftp.nlst(path)]
+            host, username, passwd, path = self._parse_url(fn)
+            if username != "anonymous":
+                template = "ftp://{un}:{pw}@{0}/{1}"
+            else:
+                template = "ftp://{0}/{1}"
+            return [template.format(host, item, un=username, pw=passwd)
+                    for item in ftp.nlst(path)]
         return super(FtpFsAccess, self).listdir(fn)
 
     def join(self, path, *paths):  # type: (Text, *Text) -> Text

--- a/cwl_tes/ftp.py
+++ b/cwl_tes/ftp.py
@@ -63,8 +63,12 @@ class FtpFsAccess(StdFsAccess):
                 if creds:
                     user, _, passwd = creds
         if not user:
-            user = "anonymous"
-            passwd = "anonymous@"
+            user, passwd = self._recall_credentials(host)
+            if passwd is None:
+                passwd = "anonymous@"
+                if user is None:
+                    user = "anonymous"
+
         return host, user, passwd, path
 
     def _connect(self, url):  # type: (Text) -> Optional[ftplib.FTP]
@@ -84,6 +88,12 @@ class FtpFsAccess(StdFsAccess):
 
     def _abs(self, p):  # type: (Text) -> Text
         return abspath(p, self.basedir)
+
+    def _recall_credentials(self, desired_host):
+        for host, user, passwd in self.cache:
+            if desired_host == host:
+                return user, passwd
+        return None, None
 
     def glob(self, pattern):  # type: (Text) -> List[Text]
         if not self.basedir.startswith("ftp:"):

--- a/cwl_tes/main.py
+++ b/cwl_tes/main.py
@@ -155,9 +155,11 @@ def main(args=None):
 
     class CachingFtpFsAccess(FtpFsAccess):
         """Ensures that the FTP connection cache is shared."""
-        def __init__(self, basedir):
-            super(CachingFtpFsAccess, self).__init__(basedir, ftp_cache)
-    ftp_fs_access = CachingFtpFsAccess(os.curdir)
+        def __init__(self, basedir, insecure=False):
+            super(CachingFtpFsAccess, self).__init__(
+                basedir, ftp_cache, insecure=insecure)
+
+    ftp_fs_access = CachingFtpFsAccess(os.curdir, insecure=parsed_args.insecure)
     if parsed_args.remote_storage_url:
         parsed_args.remote_storage_url = ftp_fs_access.join(
             parsed_args.remote_storage_url, str(uuid.uuid4()))
@@ -167,7 +169,8 @@ def main(args=None):
         remote_storage_url=parsed_args.remote_storage_url,
         token=parsed_args.token)
     runtime_context = cwltool.main.RuntimeContext(vars(parsed_args))
-    runtime_context.make_fs_access = CachingFtpFsAccess
+    runtime_context.make_fs_access = functools.partial(
+        CachingFtpFsAccess, insecure=parsed_args.insecure)
     runtime_context.path_mapper = functools.partial(
         TESPathMapper, fs_access=ftp_fs_access)
     job_executor = MultithreadedJobExecutor() if parsed_args.parallel \
@@ -407,6 +410,9 @@ def arg_parser():  # type: () -> argparse.ArgumentParser
                         type=Text, default=os.path.abspath('.'),
                         help="Output directory, default current directory")
     parser.add_argument("--remote-storage-url", type=str)
+    parser.add_argument("--insecure", action="store_true",
+                        help=("Connect securely to FTP server (ignored when "
+                              "--remote-storage-url is not set)"))
     parser.add_argument("--token", type=str)
     parser.add_argument("--token-public-key", type=str,
                         default=DEFAULT_TOKEN_PUBLIC_KEY)

--- a/cwl_tes/main.py
+++ b/cwl_tes/main.py
@@ -368,7 +368,7 @@ def set_secondary(typedef, fileobj, discovered):
     if isinstance(fileobj, MutableMapping) and fileobj.get("class") == "File":
         if "secondaryFiles" not in fileobj:
             fileobj["secondaryFiles"] = cmap(
-                [{"location": substitute(fileobj["location"], sf),
+                [{"location": substitute(fileobj["location"], sf["pattern"]),
                   "class": "File"} for sf in typedef["secondaryFiles"]])
             if discovered is not None:
                 discovered[fileobj["location"]] = fileobj["secondaryFiles"]


### PR DESCRIPTION
This PR makes several changes that allow cwl-tes to sucessfully communicate with a wider array of FTP configurations. 

* `ftp._connect` now uses `urlparse.host` instead of `urlparse.netloc` as the url for the ftp. This means the username and password will not be communicated to the ftp server as part of the url string, but are instead communicated separately through the `ftplib.FTP.login` method. 
* A new flag, `--insecure`, toggles use of the `ftptools.FTP` class instead of `FTP_TLS`
* A bug in `main.tes_execute.set_secondary` has been fixed.  Previously the dictionary representing a secondary file entry was passed to a function instead of the specific value in the dictionary that the function requires, which raised a `TypeError` for passing a dictionary in place of a string. 
* Previously there would circumstances that would cause `cwl-tes` to send ftp requests without adding the credential data to the request. This has been fixed by leveraging the already-existing data structure `FtpFsAccess.cache`, which stores `ftplib.FTP` objects representing open connections. If an `FtpFsAccess` object is asked to make a request to an FTP server that has an open connection in `cache`, but the credential information was not explicitly provided in the url then `cwl-tes` will use the credential information stored in `cache` to login. If multiple open credentials to the server are stored in `cache`, the first encountered one will be used. 