### PR TITLE
ENH: S3 backend

### DIFF
--- a/cwl_tes/main.py
+++ b/cwl_tes/main.py
@@ -7,11 +7,11 @@ import functools
 import signal
 import sys
 import logging
-import ftplib
 import jwt
 import uuid
 from typing import MutableMapping, MutableSequence
 from typing_extensions import Text
+from urllib.parse import urlparse
 
 import pkg_resources
 from six.moves import urllib
@@ -32,7 +32,9 @@ from cwltool.process import Process
 
 from .tes import make_tes_tool, TESPathMapper
 from .__init__ import __version__
+
 from .ftp import FtpFsAccess
+from .s3 import S3FsAccess, parse_s3_endpoint_url
 
 log = logging.getLogger("tes-backend")
 log.setLevel(logging.INFO)
@@ -55,10 +57,10 @@ def versionstring():
     return "%s %s with cwltool %s" % (sys.argv[0], __version__, cwltool_ver)
 
 
-def ftp_upload(base_url, fs_access, cwl_obj):
+def fs_upload(base_url, fs_access, cwl_obj):
     # type: (Text, FtpFsAccess, Dict[Text, Any]) -> None
     """
-    Upload a File or Directory to the given FTP URL;
+    Upload a File or Directory to the given backend URL (FTP or S3);
 
     Update the location URL to match.
     """
@@ -76,7 +78,7 @@ def ftp_upload(base_url, fs_access, cwl_obj):
         raise ValueError("Passed a file but Class is not File")
     try:
         fs_access.mkdir(base_url)
-    except ftplib.all_errors:
+    except Exception:
         pass
     if not fs_access.isdir(base_url):
         raise Exception(
@@ -101,6 +103,35 @@ def ftp_upload(base_url, fs_access, cwl_obj):
         else:
             with open(path, mode="rb") as source:
                 fs_access.upload(source, cwl_obj["location"])
+
+
+def _create_ftp_fs_access_factory(parsed_args):
+    """ Return a callable that creates an FtpFsAccess instance.
+    """
+    ftp_cache = {}
+
+    class CachingFtpFsAccess(FtpFsAccess):
+        """Ensures that the FTP connection cache is shared."""
+        def __init__(self, basedir, insecure=False):
+            super(CachingFtpFsAccess, self).__init__(
+                basedir, ftp_cache, insecure=insecure)
+
+    factory = functools.partial(
+        CachingFtpFsAccess, insecure=parsed_args.insecure
+    )
+    return factory
+
+
+def _create_s3_fs_access_factory(parsed_args):
+    """ Return a callable that creates an S3FsAccess instance.
+    """
+    endpoint, insecure, bucket = parse_s3_endpoint_url(
+        parsed_args.remote_storage_url)
+
+    factory = functools.partial(
+        S3FsAccess, url=endpoint, insecure=insecure
+    )
+    return factory
 
 
 def main(args=None):
@@ -151,28 +182,31 @@ def main(args=None):
         sys.exit(1)
     signal.signal(signal.SIGINT, signal_handler)
 
-    ftp_cache = {}
+    remote_storage_url = parsed_args.remote_storage_url
+    scheme = urlparse(remote_storage_url).scheme
+    if scheme in ('http', 'https'):
+        make_fs_access = _create_s3_fs_access_factory(parsed_args)
+        storage_location = parse_s3_endpoint_url(
+            parsed_args.remote_storage_url)[2]
+    else:
+        make_fs_access = _create_s3_fs_access_factory(parsed_args)
+        storage_location = remote_storage_url
 
-    class CachingFtpFsAccess(FtpFsAccess):
-        """Ensures that the FTP connection cache is shared."""
-        def __init__(self, basedir, insecure=False):
-            super(CachingFtpFsAccess, self).__init__(
-                basedir, ftp_cache, insecure=insecure)
+    fs_access = make_fs_access(os.curdir)
 
-    ftp_fs_access = CachingFtpFsAccess(os.curdir, insecure=parsed_args.insecure)
-    if parsed_args.remote_storage_url:
-        parsed_args.remote_storage_url = ftp_fs_access.join(
-            parsed_args.remote_storage_url, str(uuid.uuid4()))
+    if remote_storage_url:
+        data_url = fs_access.join(storage_location, str(uuid.uuid4()))
+        parsed_args.remote_storage_url = data_url
+
     loading_context = cwltool.main.LoadingContext(vars(parsed_args))
     loading_context.construct_tool_object = functools.partial(
         make_tes_tool, url=parsed_args.tes,
         remote_storage_url=parsed_args.remote_storage_url,
         token=parsed_args.token)
     runtime_context = cwltool.main.RuntimeContext(vars(parsed_args))
-    runtime_context.make_fs_access = functools.partial(
-        CachingFtpFsAccess, insecure=parsed_args.insecure)
+    runtime_context.make_fs_access = make_fs_access
     runtime_context.path_mapper = functools.partial(
-        TESPathMapper, fs_access=ftp_fs_access)
+        TESPathMapper, fs_access=fs_access)
     job_executor = MultithreadedJobExecutor() if parsed_args.parallel \
         else SingleJobExecutor()
     job_executor.max_ram = job_executor.max_cores = float("inf")
@@ -180,7 +214,7 @@ def main(args=None):
         tes_execute, job_executor=job_executor,
         loading_context=loading_context,
         remote_storage_url=parsed_args.remote_storage_url,
-        ftp_access=ftp_fs_access)
+        fs_access=fs_access)
     return cwltool.main.main(
         args=parsed_args,
         executor=executor,
@@ -197,7 +231,7 @@ def tes_execute(process,           # type: Process
                 job_executor,      # type: JobExecutor
                 loading_context,   # type: LoadingContext
                 remote_storage_url,
-                ftp_access,
+                fs_access,
                 logger=log
                 ):  # type: (...) -> Tuple[Optional[Dict[Text, Any]], Text]
     """
@@ -207,7 +241,7 @@ def tes_execute(process,           # type: Process
     https://github.com/curoverse/arvados/blob/2b0b06579199967eca3d44d955ad64195d2db3c3/sdk/cwl/arvados_cwl/__init__.py#L407
     """
     if remote_storage_url:
-        upload_workflow_deps_ftp(process, remote_storage_url, ftp_access)
+        upload_workflow_deps(process, remote_storage_url, fs_access)
         # Reload tool object which may have been updated by
         # upload_workflow_deps
         # Don't validate this time because it will just print redundant errors.
@@ -218,15 +252,15 @@ def tes_execute(process,           # type: Process
         loading_context.do_validate = False
         process = loading_context.construct_tool_object(
             process.doc_loader.idx[process.tool["id"]], loading_context)
-        job_order = upload_job_order_ftp(
-            process, job_order, remote_storage_url, ftp_access)
+        job_order = upload_job_order_fs(
+            process, job_order, remote_storage_url, fs_access)
 
     if not job_executor:
         job_executor = MultithreadedJobExecutor()
     return job_executor(process, job_order, runtime_context, logger)
 
 
-def upload_workflow_deps_ftp(process, remote_storage_url, ftp_access):
+def upload_workflow_deps(process, remote_storage_url, fs_access):
     """
     Ensure that all default files in this workflow are uploaded.
 
@@ -237,16 +271,16 @@ def upload_workflow_deps_ftp(process, remote_storage_url, ftp_access):
 
     def upload_tool_deps(deptool):
         if "id" in deptool:
-            upload_dependencies_ftp(document_loader, deptool, deptool["id"],
-                                    True, remote_storage_url, ftp_access)
+            upload_dependencies_fs(document_loader, deptool, deptool["id"],
+                                   True, remote_storage_url, fs_access)
             document_loader.idx[deptool["id"]] = deptool
     process.visit(upload_tool_deps)
 
 
-def upload_dependencies_ftp(document_loader, workflowobj, uri, loadref_run,
-                            remote_storage_url, ftp_access):
+def upload_dependencies_fs(document_loader, workflowobj, uri, loadref_run,
+                           remote_storage_url, fs_access):
     """
-    Upload the dependencies of the workflowobj document to an FTP location.
+    Upload the dependencies of the workflowobj document to an FTP/S3 location.
 
     Does an in-place update of references in "workflowobj".
     Use scandeps to find $import, $include, $schemas, run, File and Directory
@@ -294,7 +328,7 @@ def upload_dependencies_ftp(document_loader, workflowobj, uri, loadref_run,
                 fileobj["location"] = fileobj["path"]
                 del fileobj["path"]
             if "location" in fileobj \
-                    and not ftp_access.exists(fileobj["location"]):
+                    and not fs_access.exists(fileobj["location"]):
                 # Delete "default" from workflowobj
                 remove[0] = True
         visit_class(obj["default"], ("File", "Directory"),
@@ -320,13 +354,13 @@ def upload_dependencies_ftp(document_loader, workflowobj, uri, loadref_run,
         if not entry.startswith("file:"):
             del discovered[entry]
     visit_class(workflowobj, ("Directory"), functools.partial(
-        ftp_upload, remote_storage_url, ftp_access))
+        fs_upload, remote_storage_url, fs_access))
     visit_class(workflowobj, ("File"), functools.partial(
-        ftp_upload, remote_storage_url, ftp_access))
+        fs_upload, remote_storage_url, fs_access))
     visit_class(discovered, ("Directory"), functools.partial(
-        ftp_upload, remote_storage_url, ftp_access))
+        fs_upload, remote_storage_url, fs_access))
     visit_class(discovered, ("File"), functools.partial(
-        ftp_upload, remote_storage_url, ftp_access))
+        fs_upload, remote_storage_url, fs_access))
 
 
 def find_defaults(item, operation):
@@ -380,7 +414,7 @@ def set_secondary(typedef, fileobj, discovered):
             set_secondary(typedef, entry, discovered)
 
 
-def upload_job_order_ftp(process, job_order, remote_storage_url, ftp_access):
+def upload_job_order_fs(process, job_order, remote_storage_url, fs_access):
     """
     Upload local files referenced in the input object and return updated input
     object with 'location' updated to new URIs.
@@ -389,9 +423,9 @@ def upload_job_order_ftp(process, job_order, remote_storage_url, ftp_access):
     https://github.com/curoverse/arvados/blob/2b0b06579199967eca3d44d955ad64195d2db3c3/sdk/cwl/arvados_cwl/runner.py#L266
     """
     discover_secondary_files(process.tool["inputs"], job_order)
-    upload_dependencies_ftp(process.doc_loader, job_order,
-                            job_order.get("id", "#"), False,
-                            remote_storage_url, ftp_access)
+    upload_dependencies_fs(process.doc_loader, job_order,
+                           job_order.get("id", "#"), False,
+                           remote_storage_url, fs_access)
     if "id" in job_order:
         del job_order["id"]
     # Need to filter this out, gets added by cwltool when providing

--- a/cwl_tes/s3.py
+++ b/cwl_tes/s3.py
@@ -1,0 +1,266 @@
+import fnmatch
+import glob
+import io
+import os
+from typing import IO, Any, List
+from urllib.parse import urlparse, urlunparse
+
+from cwltool.stdfsaccess import StdFsAccess
+from cwltool.loghandler import _logger
+
+import minio
+
+
+def is_s3(url):
+    """ Check if an URI refers to an S3 resource.
+
+    S3 resources are represented by URIs of the form s3://bucket/key.
+
+    """
+    return urlparse(url).scheme == 's3'
+
+
+def parse_s3_endpoint_url(url):
+    """ Parse an S3 endpoint URL into its constituent parts.
+
+    S3 endpoint URLs can be either in "path-style", i.e. of the form::
+
+      https://hostname/bucket/key
+
+    or of the form `s3://bucket/key`. In the latter case, it is assumed
+    that we're talking to a bucket hosted on Amazon S3.
+
+    """
+    parse = urlparse(url)
+
+    if parse.scheme == 's3':
+        netloc = "s3.amazonaws.com"
+        insecure = False
+    else:
+        netloc = parse.netloc
+        insecure = parse.scheme == "http"
+        url = "s3:/" + parse.path
+
+    return netloc, insecure, url
+
+
+class S3FsAccess(StdFsAccess):
+    """ File system abstraction backed by an S3-like bucket (S3, Minio, ...)
+
+    Based on the FtpFsAccess implementation. This implementation uses the
+    Minio client for convenience, but can be used to access resources on
+    Amazon S3 and on a Minio server without any difference.
+
+    Access credentials for the bucket are taken from the environment and should
+    be set via the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment
+    variables.
+
+    """
+
+    def __init__(self, basedir, url, insecure=False):  # type: (str) -> None
+        """Perform operations with respect to a base directory."""
+
+        super().__init__(basedir)
+
+        self._client = minio.Minio(
+            url,
+            access_key=os.environ["AWS_ACCESS_KEY_ID"],
+            secret_key=os.environ["AWS_SECRET_ACCESS_KEY"],
+            secure=not insecure,
+        )
+
+    def glob(self, pattern):  # type: (str) -> List[str]
+        """ Find keys in the bucket that match a given pattern.
+
+        Patterns are of the form::
+
+            s3://bucket/some/key/that/*.has/some/magic/in/it
+
+        """
+        _logger.debug("glob() for %s", pattern)
+
+        # Shortcut: we have a pattern without a magic in it. Simply check if
+        # the resource exists, and return early.
+        if not glob.has_magic(pattern):
+            # Single path
+            if self.exists(pattern):
+                return [pattern]
+            else:
+                return []
+
+        # We have a magic. Try to isolate a prefix in the path that has no
+        # magic in it, and list keys under that prefix, so that we don't have
+        # to list and filter the whole bucket, which may be huge.
+        bucket, path = _parse_bucket_url(pattern)
+        prefix, _ = _split_on_magic(path)
+
+        # List objects under prefix.
+        objs = self._client.list_objects(bucket, prefix=prefix, recursive=True)
+        keys = [obj.object_name for obj in objs]
+
+        # Filter against given pattern
+        matching_keys = fnmatch.filter(keys, path)
+        return [_make_bucket_url(bucket, path) for path in matching_keys]
+
+    def open(self, fn, mode):  # type: (str, str) -> IO[Any]
+        """ Open a bucket resource for access.
+        """
+        _logger.debug("open() for %s with mode %s", fn, mode)
+
+        if not is_s3(fn):
+            return super().open(fn, mode)
+
+        bucket, relpath = _parse_bucket_url(fn)
+        resp = self._client.get_object(bucket, relpath)
+        return resp
+
+    def exists(self, fn):  # type: (str) -> bool
+        """ Check whether a bucket resource exists.
+        """
+        _logger.debug("exists() for %s", fn)
+
+        if not is_s3(fn):
+            return super().exists(fn)
+
+        bucket, relpath = _parse_bucket_url(fn)
+        if not relpath:
+            return self._client.bucket_exists(bucket)
+
+        objs = self._client.list_objects(bucket, prefix=relpath)
+        paths = [obj.object_name for obj in objs]
+
+        return relpath in paths or relpath + '/' in paths
+
+    def size(self, fn):  # type: (str) -> int
+        """ Return the size of a bucket resource (in bytes).
+        """
+        _logger.debug("size() for %s", fn)
+
+        if not is_s3(fn):
+            return super().size(fn)
+
+        bucket, relpath = _parse_bucket_url(fn)
+        obj = self._client.stat_object(bucket, relpath)
+        return obj.size
+
+    def isfile(self, fn):  # type: (str) -> bool
+        """ Check if a bucket resource exists and is a file.
+
+        Note: S3 does not really distinguish between files and directory.
+        Consequently, this function (and `isdir`) merely check that the
+        given object exists.
+
+        """
+        _logger.debug("isfile() for %s", fn)
+
+        if not is_s3(fn):
+            return super().isfile(fn)
+
+        return self.exists(fn)
+
+    def isdir(self, fn):  # type: (str) -> bool
+        """ Check if a bucket resource exists and is a directory.
+
+        Note: S3 does not really distinguish between files and directory.
+        Consequently, this function (and `isfile`) merely check that the
+        given object exists.
+
+        """
+        _logger.debug("isdir() for %s", fn)
+
+        if not is_s3(fn):
+            return super().isdir(fn)
+
+        return self.exists(fn)
+
+    def mkdir(self, url, recursive=True):
+        """ Make a directory inside the bucket.
+
+        Note: an S3 directory is simply an object whose name ends in a
+        forward slash.
+
+        """
+        _logger.debug("mkdir() for %s", url)
+
+        bucket, relpath = _parse_bucket_url(url)
+        if not relpath:
+            return
+
+        if not relpath.endswith('/'):
+            relpath += '/'
+
+        self._client.put_object(bucket, relpath, io.BytesIO(), 0)
+
+    def listdir(self, fn):  # type: (str) -> List[str]
+        """ List all objects in a given bucket (non-recursively).
+        """
+        _logger.debug("listdir() for %s", fn)
+
+        bucket, relpath = _parse_bucket_url(fn)
+
+        prefix = relpath or None
+        objs = self._client.list_objects(bucket, prefix=prefix)
+
+        return [
+            _make_bucket_url(obj.bucket_name, obj.object_name) for obj in objs
+        ]
+
+    def join(self, path, *paths):  # type: (str, *str) -> str
+        """ Join bucket paths.
+        """
+        _logger.debug("join() for %s, %s", path, ', '.join(paths))
+
+        if not is_s3(path):
+            return super().join(path, *paths)
+
+        return path + '/' + '/'.join(paths)
+
+    def realpath(self, path):  # type: (str) -> str
+        """ Return the real path for a bucket resource.
+
+        This is a no-op.
+
+        """
+        _logger.debug("realpath() for %s", path)
+
+        if not is_s3(path):
+            return super().realpath(path)
+
+        return path
+
+    def upload(self, handle, fn):
+        """ Upload a resource to the bucket.
+
+        The resource is identified by an open file handle.
+
+        """
+        _logger.debug("upload() for %s", fn)
+
+        bucket, relpath = _parse_bucket_url(fn)
+
+        nbytes = os.fstat(handle.fileno()).st_size
+        self._client.put_object(bucket, relpath, handle, nbytes)
+
+
+def _parse_bucket_url(url):
+    """Parses a bucket URI of the form s3://bucket/path/into/bucket
+    """
+    parse = urlparse(url)
+    return parse.netloc, parse.path[1:]
+
+
+def _make_bucket_url(bucket, path):
+    return urlunparse(("s3", bucket, path, None, None, None))
+
+
+def _split_on_magic(path):
+    """ Split path into two parts, so that the second part starts with a glob.
+
+    If the path does not contain a magic, the second part is empty.
+
+    """
+    parts = path.split('/')
+    for i, part in enumerate(parts):
+        if glob.has_magic(part):
+            break
+    return '/'.join(parts[:i]), '/'.join(parts[i:])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 cwltool==1.0.20191022103248
 future>=0.16.0
 requests>=2.18.2
+minio>=4.0.18
 py-tes>=0.4.0
 PyJWT>=1.6.4
 typing_extensions>=3.7.4


### PR DESCRIPTION
This is a first cut of an S3 backend for cwl-tes. It works pretty much the same way as the FTP backend: resources get uploaded to S3 and URLs in the workflow are rewritten to point to S3.

Activating the backend happens through the `--remote-storage-url` parameter: if this is a HTTP/S URL then it's assumed that we're talking to an S3-like system, and the URL should be of the form `http(s)://<endpoint>/<bucket>`. S3 credentials are retrieved from the environment.

Implementation-wise, the biggest change is in the addition of the `s3.py` module, which adds another subclass of the `StdFsAccess` class. The other changes are in the `main.py` module, where the biggest changes are in dispatching on the kind of remote storage URL, as well as making things reasonably polymorphic, so that the worker functions that do the uploading and parsing don't have to care about the type of storage backend. 

I wanted to share this at this point to get some input about design and future directions. I've only tried this with Minio, and while I've tried to leave the original FTP interface intact, I've not yet tested this in practice. I've also paid very little attention to unit tests (but would be glad to remedy this).

Very glad to hear comments and suggestions!