### PR TITLE
(Try to) Fix tests, drop Python 2.7, 3.5; add 3.8

### DIFF
--- a/cwl_tes/ftp.py
+++ b/cwl_tes/ftp.py
@@ -36,7 +36,8 @@ def abspath(src, basedir):  # type: (Text, Text) -> Text
 
 class FtpFsAccess(StdFsAccess):
     """FTP access with upload."""
-    def __init__(self, basedir, cache=None, insecure=False):  # type: (Text) -> None
+    def __init__(
+            self, basedir, cache=None, insecure=False):  # type: (Text) -> None
         super(FtpFsAccess, self).__init__(basedir)
         self.cache = cache or {}
         self.netrc = None

--- a/cwl_tes/main.py
+++ b/cwl_tes/main.py
@@ -159,7 +159,8 @@ def main(args=None):
             super(CachingFtpFsAccess, self).__init__(
                 basedir, ftp_cache, insecure=insecure)
 
-    ftp_fs_access = CachingFtpFsAccess(os.curdir, insecure=parsed_args.insecure)
+    ftp_fs_access = CachingFtpFsAccess(
+        os.curdir, insecure=parsed_args.insecure)
     if parsed_args.remote_storage_url:
         parsed_args.remote_storage_url = ftp_fs_access.join(
             parsed_args.remote_storage_url, str(uuid.uuid4()))

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     url="https://github.com/common-workflow-language/cwl-tes",
     license="Apache 2.0",
     packages=find_packages(),
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4",
+    python_requires="!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5*, <4",
     install_requires=[
         "cwltool==1.0.20191022103248",
         "future>=0.16.0",
@@ -49,7 +49,7 @@ setup(
     ],
     extras_require={
         "test": [
-            "cwltest>=1.0.20190228134645",
+            "cwltest==1.0.20190228134645",
             "nose>=1.3.7",
             "flake8>=3.7.0",
             "PyYAML>=3.12"
@@ -62,9 +62,8 @@ setup(
         "Development Status :: 3 - Alpha",
         "Natural Language :: English",
         "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,21 @@
 [tox]
 envlist =
-  py{27,35,36,37}-lint,
-  py{27,35,36,37}-unit
+  py{36,37,38}-lint,
+  py{36,37,38}-unit
 skip_missing_interpreters = True
 
 [testenv]
 passenv = CI TRAVIS TRAVIS_*
 deps =
   -rrequirements.txt
-  py{27,35,36,37}-unit: .[test]
-  py{27,35,36,37}-lint: flake8>=3.7.0
+  py{36,37,38}-unit: .[test]
+  py{36,37,38}-lint: flake8>=3.7.0
 commands =
-  py{27,35,36,37}-unit: - wget -nc -O /tmp/funnel.tar.gz https://github.com/ohsu-comp-bio/funnel/releases/download/0.7.0/funnel-linux-amd64-0.7.0.tar.gz
-  py{27,35,36,37}-unit: tar -zxvf /tmp/funnel.tar.gz -C {envbindir}
-  py{27,35,36,37}-unit: git submodule update --init --recursive
-  py{27,35,36,37}-unit: python -m nose tests {posargs}
-  py{27,35,36,37}-lint: flake8 cwl_tes
+  py{36,37,38}-unit: - wget -nc -O /tmp/funnel.tar.gz https://github.com/ohsu-comp-bio/funnel/releases/download/0.7.0/funnel-linux-amd64-0.7.0.tar.gz
+  py{36,37,38}-unit: tar -zxvf /tmp/funnel.tar.gz -C {envbindir}
+  py{36,37,38}-unit: git submodule update --init --recursive
+  py{36,37,38}-unit: python -m nose tests {posargs}
+  py{36,37,38}-lint: flake8 cwl_tes
 whitelist_externals =
   wget
   tar


### PR DESCRIPTION
I was anticipating working on #38, but before doing so, I wanted to make sure the test suite passed correctly.

I noticed a few Python-3 only constructs in the code and assumed that Python 2.7 was implicitly no longer supported. Consequently I removed it, as well as Python 3.5 (EOL Sept 2020). I also added Python 3.8 to the testing matrix. On my machine at least, tests pass for these Python versions, with some small changes that needed to be made.

Changes to the codebase:
- Pin cwltest to the exact version specified in setup.py. There was a failing test with cwltest requiring  a higher version of schema-salad than was installed (as a dependency of cwltool).
- Fix some flake8 errors that I introduced (!) in an earlier PR; apologies for that.