### PR TITLE
Aws support

### DIFF
--- a/cwl_tes/ftp.py
+++ b/cwl_tes/ftp.py
@@ -9,7 +9,7 @@ import netrc
 import glob
 import os
 from typing import List, Text  # noqa F401 # pylint: disable=unused-import
-
+import sys
 from six import PY2
 from six.moves import urllib
 from schema_salad.ref_resolver import uri_file_path
@@ -31,6 +31,8 @@ def abspath(src, basedir):  # type: (Text, Text) -> Text
             apath = src if os.path.isabs(src) else basedir + '/' + src
         else:
             apath = src if os.path.isabs(src) else os.path.join(basedir, src)
+    #raise Exception("abspath: Source {}\n basedir {} \nScheme {} \nreturns {}".format(src, basedir, scheme, apath))
+    
     return apath
 
 
@@ -39,7 +41,9 @@ class FtpFsAccess(StdFsAccess):
     def __init__(
             self, basedir, cache=None, insecure=False):  # type: (Text) -> None
         super(FtpFsAccess, self).__init__(basedir)
+        print("Initializing FTPFsAccess object")
         self.cache = cache or {}
+        self.uuid=None
         self.netrc = None
         self.insecure = insecure
         try:
@@ -91,11 +95,18 @@ class FtpFsAccess(StdFsAccess):
     def _abs(self, p):  # type: (Text) -> Text
         return abspath(p, self.basedir)
 
+    def setUUID(self, uuid):
+        self.uuid=uuid
+    def getUUID(self):
+        return(self.uuid)
+
+
     def _recall_credentials(self, desired_host):
         for host, user, passwd in self.cache:
             if desired_host == host:
                 return user, passwd
         return None, None
+
 
     def glob(self, pattern):  # type: (Text) -> List[Text]
         if not self.basedir.startswith("ftp:"):
@@ -146,6 +157,8 @@ class FtpFsAccess(StdFsAccess):
         return results
 
     def open(self, fn, mode):
+        print("ftp OPEN for {} {}".format(fn, mode))
+        sys.exit(1)
         if not fn.startswith("ftp:"):
             return super(FtpFsAccess, self).open(fn, mode)
         if 'r' in mode:

--- a/cwl_tes/main.py
+++ b/cwl_tes/main.py
@@ -20,6 +20,10 @@ from six import itervalues, StringIO
 from ruamel import yaml
 from schema_salad.sourceline import cmap
 from typing import Any, Dict, Tuple, Optional
+
+
+
+
 import cwltool.main
 from cwltool.builder import substitute
 from cwltool.context import LoadingContext, RuntimeContext
@@ -33,6 +37,15 @@ from cwltool.process import Process
 from .tes import make_tes_tool, TESPathMapper
 from .__init__ import __version__
 from .ftp import FtpFsAccess
+from cwl_tes.s3 import AWSS3Access
+
+
+
+
+
+
+
+
 
 log = logging.getLogger("tes-backend")
 log.setLevel(logging.INFO)
@@ -43,6 +56,80 @@ log.addHandler(console)
 
 DEFAULT_TMP_PREFIX = "tmp"
 DEFAULT_TOKEN_PUBLIC_KEY = os.environ.get('TOKEN_PUBLIC_KEY', '')
+
+
+
+
+
+# Classes to replace in cwltool
+
+
+
+# 
+# def FSActioncall(
+#     self,
+#     parser,  # type: argparse.ArgumentParser
+#     namespace,  # type: argparse.Namespace
+#     values,  # type: Union[AnyStr, Sequence[Any], None]
+#     option_string=None,  # type: Optional[str]
+# ):  # type: (...) -> None
+#     url= urllib.parse.urlparse( values )
+#     print("This is the new FSAction: __call__ : self.dest {}, values {}".format(self.dest, values))
+#     if url.scheme == '':
+#         setattr(
+#             namespace,
+#             self.dest,
+#             {
+#                 "class": self.objclass,
+#                 "location": file_uri(str(os.path.abspath(cast(AnyStr, values)))),
+#             },
+#         )
+#     else:
+#         setattr(
+#             namespace,
+#             self.dest,
+#             {
+#                 "class": self.objclass,
+#                 "location": values,
+#             },
+#         )
+#         
+# cwltool.argparser.FSAction.__call__=FSActioncall          
+#             
+#         #print("FSAction: __call__ : self.dest {}, values {} ".format(self.dest, values ))
+# 
+# 
+# 
+# def FSAppendActioncall(
+#     self,
+#     parser,  # type: argparse.ArgumentParser
+#     namespace,  # type: argparse.Namespace
+#     values,  # type: Union[AnyStr, Sequence[Any], None]
+#     option_string=None,  # type: Optional[str]
+# ):  # type: (...) -> None
+#     g = getattr(namespace, self.dest)
+#     if not g:
+#         g = []
+#         setattr(namespace, self.dest, g)
+#     url= urllib.parse.urlparse( values )
+#     print("This is the new FSAppendActionc: __call__ : self.dest {}, values {}".format(self.dest, values))
+#     if url.scheme ==  "" :
+#         g.append(
+#             {
+#                 "class": self.objclass,
+#                 "location": file_uri(str(os.path.abspath(cast(AnyStr, values)))),
+#             }
+#         )
+#     else:
+#         g.append(
+#             {
+#                 "class": self.objclass,
+#                 "location":  values,
+#             }
+#         )    
+# cwltool.argparser.FSAppendAction.__call__=FSAppendActioncall       
+
+
 
 
 def versionstring():
@@ -62,6 +149,7 @@ def ftp_upload(base_url, fs_access, cwl_obj):
 
     Update the location URL to match.
     """
+    #print("ftp_upload: CWL obj {}".format(cwl_obj) )
     if "path" not in cwl_obj and not (
             "location" in cwl_obj and cwl_obj["location"].startswith(
                 "file:/")):
@@ -153,27 +241,50 @@ def main(args=None):
 
     ftp_cache = {}
 
+    # cache the connection to the remote service 
     class CachingFtpFsAccess(FtpFsAccess):
         """Ensures that the FTP connection cache is shared."""
+ 
         def __init__(self, basedir, insecure=False):
             super(CachingFtpFsAccess, self).__init__(
                 basedir, ftp_cache, insecure=insecure)
+     
+    
+    class CachingS3FsAccess(AWSS3Access):
+        """ created only for homogeneity with the FTP counterpart. it just returns an instance of AWSS3Access"""
+        def __init__(self, basedir):
+            super(CachingS3FsAccess, self).__init__(basedir)      
+    
+    if parsed_args.remote_storage_url and parsed_args.remote_storage_url.startswith("ftp:"):
+        log.debug("Using ftp class for file management")
+        ftp_fs_access = CachingFtpFsAccess(os.curdir, insecure=parsed_args.insecure) 
+        fs_access=ftp_fs_access
+    if parsed_args.remote_storage_url and parsed_args.remote_storage_url.startswith("s3:"):
+        log.debug("Using s3 class for file management")
+        s3_fs_access = CachingS3FsAccess( os.curdir)
+        fs_access=s3_fs_access
+    
 
-    ftp_fs_access = CachingFtpFsAccess(
-        os.curdir, insecure=parsed_args.insecure)
     if parsed_args.remote_storage_url:
-        parsed_args.remote_storage_url = ftp_fs_access.join(
-            parsed_args.remote_storage_url, str(uuid.uuid4()))
+        str_uuid=str(uuid.uuid4())
+        fs_access.setUUID(str_uuid)
+        parsed_args.remote_storage_url = fs_access.join(
+            parsed_args.remote_storage_url, str_uuid)
     loading_context = cwltool.main.LoadingContext(vars(parsed_args))
     loading_context.construct_tool_object = functools.partial(
         make_tes_tool, url=parsed_args.tes,
         remote_storage_url=parsed_args.remote_storage_url,
         token=parsed_args.token)
     runtime_context = cwltool.main.RuntimeContext(vars(parsed_args))
-    runtime_context.make_fs_access = functools.partial(
+
+    if parsed_args.remote_storage_url and parsed_args.remote_storage_url.startswith("s3:"): 
+        runtime_context.make_fs_access = CachingS3FsAccess
+    else:
+        runtime_context.make_fs_access  = functools.partial(
         CachingFtpFsAccess, insecure=parsed_args.insecure)
+
     runtime_context.path_mapper = functools.partial(
-        TESPathMapper, fs_access=ftp_fs_access)
+        TESPathMapper, fs_access=fs_access)
     job_executor = MultithreadedJobExecutor() if parsed_args.parallel \
         else SingleJobExecutor()
     job_executor.max_ram = job_executor.max_cores = float("inf")
@@ -181,8 +292,13 @@ def main(args=None):
         tes_execute, job_executor=job_executor,
         loading_context=loading_context,
         remote_storage_url=parsed_args.remote_storage_url,
-        ftp_access=ftp_fs_access)
-    return cwltool.main.main(
+        ftp_access=fs_access)
+    log.info("{}".format(versionstring() ))
+    log.info("Submitting workflow: {}".format(str_uuid ))
+    
+    #print("Calling cwltool.main\n{}".format(parsed_args))
+    runtime_context.str_uuid=str_uuid
+    retval= cwltool.main.main(
         args=parsed_args,
         executor=executor,
         loadingContext=loading_context,
@@ -190,7 +306,8 @@ def main(args=None):
         versionfunc=versionstring,
         logger_handler=console
     )
-
+    #print("Runtime context {}".format(runtime_context) )
+    return retval
 
 def tes_execute(process,           # type: Process
                 job_order,         # type: Dict[Text, Any]
@@ -291,6 +408,7 @@ def upload_dependencies_ftp(document_loader, workflowobj, uri, loadref_run,
         remove = [False]
 
         def ensure_default_location(fileobj):
+            #print("ensure_default_location: Fileobj is {} ".format(fileobj))
             if "location" not in fileobj and "path" in fileobj:
                 fileobj["location"] = fileobj["path"]
                 del fileobj["path"]
@@ -371,8 +489,12 @@ def set_secondary(typedef, fileobj, discovered):
     """
     if isinstance(fileobj, MutableMapping) and fileobj.get("class") == "File":
         if "secondaryFiles" not in fileobj:
+            #print("set_secondary. is not in fileobj.{}\nwe will get it from the location {}\n with secondary files ".format(fileobj, fileobj["location"], ))
+            #[print("sf = {}\n".format( sf['pattern'] ))  for sf in typedef["secondaryFiles"] ]
             fileobj["secondaryFiles"] = cmap(
+
                 [{"location": substitute(fileobj["location"], sf["pattern"]),
+
                   "class": "File"} for sf in typedef["secondaryFiles"]])
             if discovered is not None:
                 discovered[fileobj["location"]] = fileobj["secondaryFiles"]
@@ -665,7 +787,7 @@ def arg_parser():  # type: () -> argparse.ArgumentParser
     exgroup.add_argument(
         "--compute-checksum",
         action="store_true",
-        default=True,
+        default=False,
         help="Compute checksum of contents while collecting outputs",
         dest="compute_checksum")
     exgroup.add_argument(

--- a/cwl_tes/monkey_patch.py
+++ b/cwl_tes/monkey_patch.py
@@ -1,0 +1,221 @@
+
+
+import urllib
+import os
+
+import sys
+import cwltool.argparser
+import json
+
+
+# Patch functions in argparse to enable correct parsing of non file:// inputs
+def FSActioncall(
+    self,
+    parser,  # type: argparse.ArgumentParser
+    namespace,  # type: argparse.Namespace
+    values,  # type: Union[AnyStr, Sequence[Any], None]
+    option_string=None,  # type: Optional[str]
+):  # type: (...) -> None
+    url= urllib.parse.urlparse( values )
+    print("This is the new FSAction: __call__ : self.dest {}, values {}".format(self.dest, values))
+    if url.scheme == '':
+        setattr(
+            namespace,
+            self.dest,
+            {
+                "class": self.objclass,
+                "location": file_uri(str(os.path.abspath(cast(AnyStr, values)))),
+            },
+        )
+    else:
+        setattr(
+            namespace,
+            self.dest,
+            {
+                "class": self.objclass,
+                "location": values,
+            },
+        )
+         
+cwltool.argparser.FSAction.__call__=FSActioncall          
+             
+        #print("FSAction: __call__ : self.dest {}, values {} ".format(self.dest, values ))
+ 
+ 
+ 
+def FSAppendActioncall(
+    self,
+    parser,  # type: argparse.ArgumentParser
+    namespace,  # type: argparse.Namespace
+    values,  # type: Union[AnyStr, Sequence[Any], None]
+    option_string=None,  # type: Optional[str]
+):  # type: (...) -> None
+    
+    
+    g = getattr(namespace, self.dest)
+    if not g:
+        g = []
+        setattr(namespace, self.dest, g)
+    url= urllib.parse.urlparse( values )
+    print("This is the new FSAppendActionc: __call__ : self.dest {}, values {}".format(self.dest, values))
+    if url.scheme ==  "" :
+        g.append(
+            {
+                "class": self.objclass,
+                "location": file_uri(str(os.path.abspath(cast(AnyStr, values)))),
+            }
+        )
+    else:
+        g.append(
+            {
+                "class": self.objclass,
+                "location":  values,
+            }
+        )    
+cwltool.argparser.FSAppendAction.__call__=FSAppendActioncall       
+
+
+# def file_uricall(path, split_frag=False):  # type: (str, bool) -> str
+#     
+#     print("This is the new file_uri")
+#     sys.exit(1)
+#     if path.startswith("file://"):
+#         return path
+#     if path.startswith("s3://"):
+#         return path
+#     if split_frag:
+#         pathsp = path.split("#", 2)
+#         frag = "#" + urllib.parse.quote(str(pathsp[1])) if len(pathsp) == 2 else ""
+#         urlpath = urllib.request.pathname2url(str(pathsp[0]))
+#     else:
+#         urlpath = urllib.request.pathname2url(path)
+#         frag = ""
+#     if urlpath.startswith("//"):
+#         return "file:{}{}".format(urlpath, frag)
+#     return "file://{}{}".format(urlpath, frag)
+# schema_salad.ref_resolver.file_uri._call_=file_uricall
+# # def relocateOutputscall(
+#     outputObj: CWLObjectType,
+#     destination_path: str,
+#     source_directories: Set[str],
+#     action: str,
+#     fs_access: StdFsAccess,
+#     compute_checksum: bool = True,
+#     path_mapper: Type[PathMapper] = PathMapper,
+# ) -> CWLObjectType:
+#     adjustDirObjs(outputObj, functools.partial(get_listing, fs_access, recursive=True))
+# 
+#     if action not in ("move", "copy"):
+#         return outputObj
+# 
+#     def _collectDirEntries(
+#         obj: Union[CWLObjectType, MutableSequence[CWLObjectType], None]
+#     ) -> Iterator[CWLObjectType]:
+#         if isinstance(obj, dict):
+#             if obj.get("class") in ("File", "Directory"):
+#                 yield obj
+#             else:
+#                 for sub_obj in obj.values():
+#                     for dir_entry in _collectDirEntries(sub_obj):
+#                         yield dir_entry
+#         elif isinstance(obj, MutableSequence):
+#             for sub_obj in obj:
+#                 for dir_entry in _collectDirEntries(sub_obj):
+#                     yield dir_entry
+# 
+#     def _relocate(src: str, dst: str) -> None:
+#         if src == dst:
+#             return
+# 
+#         # If the source is not contained in source_directories we're not allowed to delete it
+#         src = fs_access.realpath(src)
+#         src_can_deleted = any(
+#             os.path.commonprefix([p, src]) == p for p in source_directories
+#         )
+# 
+#         _action = "move" if action == "move" and src_can_deleted else "copy"
+# 
+#         if _action == "move":
+#             _logger.debug("Moving %s to %s", src, dst)
+#             if fs_access.isdir(src) and fs_access.isdir(dst):
+#                 # merge directories
+#                 for dir_entry in scandir(src):
+#                     _relocate(dir_entry.path, fs_access.join(dst, dir_entry.name))
+#             else:
+#                 shutil.move(src, dst)
+# 
+#         elif _action == "copy":
+#             _logger.debug("Copying %s to %s", src, dst)
+#             if fs_access.isdir(src):
+#                 if os.path.isdir(dst):
+#                     shutil.rmtree(dst)
+#                 elif os.path.isfile(dst):
+#                     os.unlink(dst)
+#                 shutil.copytree(src, dst)
+#             else:
+#                 shutil.copy2(src, dst)
+# 
+#     def _realpath(
+#         ob: CWLObjectType,
+#     ) -> None:  # should be type Union[CWLFile, CWLDirectory]
+#         if cast(str, ob["location"]).startswith("file:"):
+#             ob["location"] = file_uri(
+#                 os.path.realpath(uri_file_path(cast(str, ob["location"])))
+#             )
+#         if cast(str, ob["location"]).startswith("/"):
+#             ob["location"] = os.path.realpath(cast(str, ob["location"]))
+# 
+#     outfiles = list(_collectDirEntries(outputObj))
+#     visit_class(outfiles, ("File", "Directory"), _realpath)
+#     pm = path_mapper(outfiles, "", destination_path, separateDirs=False)
+#     stage_files(pm, stage_func=_relocate, symlink=False, fix_conflicts=True)
+# 
+#     def _check_adjust(a_file: CWLObjectType) -> CWLObjectType:
+#         print("This is check_adjust")
+#         location = cast(str, a_file["location"])
+#         if urllib.parse.urlparse(os.path.splitdrive(a_file["location"])[1] ).scheme == "" :
+#             a_file["location"] = file_uri(
+#                 pm.mapper(location)[1]
+#             )  # return the location of the file on the filesystem
+#         else:
+#             a_file["location"] = pm.mapper(location)[
+#                 0
+#             ]  # keep the original uri (e.g. s3, http, ftp, gs etc)
+#         if "contents" in a_file:
+#             del a_file["contents"]
+#         return a_file
+# 
+#     visit_class(outputObj, ("File", "Directory"), _check_adjust)
+# 
+#     if compute_checksum:
+#         visit_class(
+#             outputObj, ("File",), functools.partial(compute_checksums, fs_access)
+#         )
+#     return outputObj
+# 
+# #uncache( cwltool.process.relocateOutputs)
+# #cwltool.process.relocateOutputs.__call__=relocateOutputscall      
+# import cwltool.process
+# cwltool.process.relocateOutputs._call_=relocateOutputscall.__call__
+
+
+
+
+def replaceURI( mapper: str, cwl_output:str):
+    ''' convert the location of the output from cwltool to the original URI '''
+    pathmap={}
+    def getMapper():
+        lines=mapper.splitlines()
+        for line in lines:
+            if line.startswith( "Mapper:"):
+                dd=line.replace("Mapper: ", "")
+                pm_dict=  json.loads(  dd ) 
+                pathmap[pm_dict['target_uri']]=pm_dict
+        
+        
+    getMapper(  )
+    
+    for k in pathmap:
+        cwl_output=cwl_output.replace( k , pathmap[k]['resolved'])
+    
+    return cwl_output

--- a/cwl_tes/s3.py
+++ b/cwl_tes/s3.py
@@ -1,0 +1,303 @@
+"""AWS S3 support"""
+from __future__ import absolute_import
+
+import contextlib
+import fnmatch
+import ftplib
+import logging
+import netrc
+import glob
+import boto3
+import os
+import re
+import sys
+import exrex
+from typing import List, Text  # noqa F401 # pylint: disable=unused-import
+
+from six import PY2
+from six.moves import urllib
+from schema_salad.ref_resolver import uri_file_path
+from typing import Tuple, Optional
+
+from cwltool.stdfsaccess import StdFsAccess
+from cwltool.loghandler import _logger
+from .ftp import abspath
+
+from .s3file import S3File
+
+
+class AWSS3Access(StdFsAccess):
+    """AWS s3 access with upload."""
+    def __init__(self, basedir, cache=None):  # type: (Text) -> None
+        super(AWSS3Access, self).__init__(basedir)
+        self.cache = cache or {}
+        self.uuid=None
+        #print("Initializing AWSS3Acces object for basedir {}".format( basedir))
+
+    
+    def _parse_url(self, url):
+        # type: (Text) -> Tuple[Optional[Text], Optional[Text]]
+
+        # the s3 url can be in one of the following formats:
+        #s3://bucket/path/object
+        #s3://aws.com/bucket/path/object
+        #print("_parse_url: parsing url {}".format(url))
+        parse = urllib.parse.urlparse(url)
+        # if the parse.netloc contains something like aws...com we will consider this the server and remove it
+        if re.search( "aws.+\.com", parse.netloc ):
+            bucketM=re.search("(.+?)(/.*)", parse.path)
+            bucket=bucketM[1]
+            if bucket[0]=='/':
+                bucket=bucket[1:]
+            
+            parse=parse._replace(netloc=bucket)
+            parse=parse._replace(path=bucketM[2])
+            
+            url=urllib.parse.urlunparse(parse)
+            parse=self._parse_url( url )
+        #user = parse.username
+        #passwd = parse.password
+        bucket = parse.netloc
+        path = parse.path
+        if path[0]=='/': path=path[1:]
+        #if parse.scheme == 's3':
+
+        #print("_parse_url: bucket {} path {}".format(bucket, path))
+        return bucket, path
+
+    def _connect(self, url):  # type: (Text) -> Optional[ftplib.FTP]
+        '''caches and returns the s3 connection '''
+        parse = urllib.parse.urlparse(url)
+        if parse.scheme == 's3':
+
+            bucketname, _ = self._parse_url(url)
+            if (bucketname ) in self.cache:
+                    return self.cache[(bucketname)]
+            session = boto3.session.Session()
+            #s3=boto3.resource('s3')
+            #bucket=s3.Bucket(  bucketname )
+            
+            #ftp = ftplib.FTP_TLS()
+            #ftp.set_debuglevel(1 if _logger.isEnabledFor(logging.DEBUG) else 0)
+            #ftp.connect(host)
+            #ftp.login(user, passwd)
+            self.cache[(bucketname)] = session
+            return session
+            #return bucket
+        return None
+
+    def setUUID(self, uuid):
+        self.uuid=uuid
+    def getUUID(self):
+        return(self.uuid)
+
+    def _abs(self, p):  # type: (Text) -> Text
+        return abspath(p, self.basedir)
+
+    def glob(self, pattern):  # type: (Text) -> List[Text]
+        #print("GLOB pattern {}".format(pattern))
+        if not self.basedir.startswith("s3:"):
+            return super(AWSS3Access, self).glob(pattern)
+        return self._glob(pattern)
+
+    def _glob0(self, basename, basepath):
+        #print("_GLOB0  basename {} basepath {}".format(basename , basepath))
+        if basename == '':
+            if self.isdir(basepath):
+                return [basename]
+        else:
+            if self.isfile(self.join(basepath, basename)):
+                return [basename]
+        return []
+
+    def _glob1(self, pattern, basepath=None):
+        #print("_GLOB1  pattern {} basepath {}".format(pattern , basepath))
+        try:
+            names = self.listdir(basepath)
+        except :
+            return []
+        if pattern[0] != '.':
+            names = filter(lambda x: x[0] != '.', names)
+        return fnmatch.filter(names, pattern)
+
+    def _glob(self, pattern):  # type: (Text) -> List[Text]
+        if pattern.endswith("/."):
+            pattern = pattern[:-1]
+        dirname, basename = pattern.rsplit('/', 1)
+        
+        #print("_GLOB dirname {} basename {}".format(dirname, basename))
+        if not glob.has_magic(pattern):
+            #print("Glbod does not have magic")
+            if basename:
+                if self.exists(pattern):
+                    return [pattern]
+            else:  # Patterns ending in slash should match only directories
+                if self.isdir(dirname):
+                    return [pattern]
+            return []
+        if not dirname:
+            #print("We don't have dirname")
+            return self._glob1(basename)
+
+        dirs = self._glob(dirname)
+        if glob.has_magic(basename):
+            glob_in_dir = self._glob1
+        else:
+            glob_in_dir = self._glob0
+        results = []
+        for dirname in dirs:
+            results.extend(glob_in_dir(basename, dirname))
+        return results
+#import exrex
+# import boto3
+# session = boto3.Session() # profile_name='xyz'
+# s3 = session.resource('s3')
+# bucket = s3.Bucket('mybucketname')
+# 
+# prefixes = list(exrex.generate(r'api/v2/responses/2016-11-08/(2016-11-08T2[2-3]|2016-11-09)'))
+# 
+# objects = []
+# for prefix in prefixes:
+#     print(prefix, end=" ")
+#     current_objects = list(bucket.objects.filter(Prefix=prefix))
+#     print(len(current_objects))
+#     objects += current_objects
+    def open(self, fn, mode):
+        
+        #print("s3 OPEN for {} {}".format(fn, mode))
+        #sys.exit(1)
+        
+        if not fn.startswith("s3:"):
+            return super(AWSS3Access, self).open(fn, mode)
+        if 'r' in mode:
+            s3session=self._connect(fn)
+            bucket, path = self._parse_url(fn)
+            s3bucket=s3session.client('s3')
+            handle = s3bucket.get_object(Bucket=bucket, Key=path)['Body']
+            
+            s3 = boto3.resource("s3")
+            s3_object = s3.Object(bucket_name=bucket, key=path)
+            return S3File( s3_object )
+        raise Exception('Write mode s3 not implemented')
+
+    def exists(self, fn):  # type: (Text) -> bool
+        #print("EXISTS for file {}".format(fn))
+        if not fn.startswith("s3:"):
+            return super(AWSS3Access, self).exists(fn)
+        return self.isfile(fn) or self.isdir(fn)
+
+    def isfile(self, fn):  # type: (Text) -> bool
+        #print("IS FILE for file {}".format(fn))
+        s3session = self._connect(fn)
+        
+        if s3session:
+            try:
+                sz=self.size(fn)
+                if sz is None: 
+                    #print("Return False")
+                    return False
+                #print("Return True")
+                return True
+            except :
+                #print("Return False")
+                return False
+        return super(AWSS3Access, self).isfile(fn)
+
+    def isdir(self, fn):  # type: (Text) -> bool
+        ''' to check if a fn is really a directory
+            we list all the objects under this prefix
+            It is important not to have a / at teh beginnint of the path'''
+        #print("IS DIR for file {}".format(fn))
+        s3session = self._connect(fn) # this is a resource for the bucket
+        if s3session:
+            try:
+                (bucketname, path)=self._parse_url( fn )
+                if path[0] == '/':
+                    path=path[1:]
+                if path[-1] != '/':
+                    path=path + '/'
+                contents=0
+                s3bucket=s3session.client('s3')
+                for o in s3bucket.list_objects_v2(Bucket=bucketname, Prefix=path)['Contents']:
+                    contents=contents+1
+                    if contents >0:
+                        #print("Return True")
+                        return True
+                #print("Return False")
+                return False
+            except:
+                #print("Return False")
+                return False
+        return super(AWSS3Access, self).isdir(fn)
+
+    def mkdir(self, url, recursive=True):
+        """Make the directory specified in the URL. For s3 it just creates an ojbect that ends with /"""
+        s3session = self._connect(url)
+        bucketname,path = self._parse_url(url)
+        if path[0] == '/':
+            path=path[1:]
+        if path[-1] != '/':
+            path=path + '/'
+        try:
+            s3bucket=s3session.client('s3')
+            s3bucket.put_object(Bucket=bucketname, Key=path)
+            return True
+        except:
+            return False
+        return None
+
+    def listdir(self, fn):  # type: (Text) -> List[Text]
+        s3session = self._connect(fn)
+        if s3session:
+            bucketname, path = self._parse_url(fn)
+            #print("s3.py: bucketname {} path {}".format( bucketname, path))
+            s3bucket=s3session.client('s3')
+            if path[0]=='/':path=path[1:]
+            if path[-1]!='/':path=path+'/'
+            #print("s3.py: bucketname {} path {}".format( bucketname, path))
+            
+            return ["s3://{}/{}".format(bucketname, x['Key']) for x in s3bucket.list_objects_v2(Bucket=bucketname, Prefix=path)['Contents']]
+        return super(AWSS3Access, self).listdir(fn)
+
+    def join(self, path, *paths):  # type: (Text, *Text) -> Text
+        if path.startswith('s3:'):
+            result = path
+            for extra_path in paths:
+                if extra_path.startswith('s3:/'):
+                    result = extra_path
+                else:
+                    if result[-1]=='/': result=result[:-1]
+                    result = result + "/" + extra_path
+            return result
+        return super(AWSS3Access, self).join(path, *paths)
+
+    def realpath(self, path):  # type: (Text) -> Text
+        if path.startswith('s3:'):
+            return path
+        return os.path.realpath(path)
+
+    def size(self, fn):
+        s3session = self._connect(fn)
+        #raise Exception("size: getting size for {}".format(fn))
+        if s3session:
+            bucketname, path = self._parse_url(fn)
+            
+            try:
+                s3bucket=s3session.client('s3')
+                object=s3bucket.head_object(Bucket=bucketname, Key=path)
+                size=object['ContentLength']
+                return size
+            except :
+                return None
+
+        return super(AWSS3Access, self).size(fn)
+
+    def upload(self, file_handle, url):
+        """s3 specific method to upload a file to the given URL."""
+        s3session = self._connect(url)
+        try:
+            s3bucket=s3session.client('s3')
+            bucketname,path=self._parse_url(url)
+            s3bucket.upload_file( Bucket=bucketname, Filename=file_handle, Key=path)
+        except:
+            raise Exception("Cannot store file {} to {}".format( file_handle, path))

--- a/cwl_tes/s3file.py
+++ b/cwl_tes/s3file.py
@@ -1,0 +1,57 @@
+import io
+
+
+class S3File(io.RawIOBase):
+    def __init__(self, s3_object):
+        self.s3_object = s3_object
+        self.position = 0
+
+    def __repr__(self):
+        return "<%s s3_object=%r>" % (type(self).__name__, self.s3_object)
+
+    @property
+    def size(self):
+        return self.s3_object.content_length
+
+    def tell(self):
+        return self.position
+
+    def seek(self, offset, whence=io.SEEK_SET):
+        if whence == io.SEEK_SET:
+            self.position = offset
+        elif whence == io.SEEK_CUR:
+            self.position += offset
+        elif whence == io.SEEK_END:
+            self.position = self.size + offset
+        else:
+            raise ValueError("invalid whence (%r, should be %d, %d, %d)" % (
+                whence, io.SEEK_SET, io.SEEK_CUR, io.SEEK_END
+            ))
+
+        return self.position
+
+    def seekable(self):
+        return True
+
+    def read(self, size=-1):
+        if self.position >= self.size:
+            return ''
+        if size == -1:
+            # Read to the end of the file
+            range_header = "bytes=%d-" % self.position
+            self.seek(offset=0, whence=io.SEEK_END)
+        else:
+            new_position = self.position + size
+
+            # If we're going to read beyond the end of the object, return
+            # the entire object.
+            if new_position >= self.size:
+                return self.read()
+
+            range_header = "bytes=%d-%d" % (self.position, new_position - 1)
+            self.seek(offset=size, whence=io.SEEK_CUR)
+        #print("Range header {}".format(range_header))
+        return self.s3_object.get(Range=range_header)["Body"].read()
+
+    def readable(self):
+        return True


### PR DESCRIPTION
This is a first attempt to enable the use of cwl-tes with AWS.
The script is processing files on s3 and stores output on s3.

It patches cwltool to enable the use of s3 URIs as inputs, and monitors the output and logs from cwltool (and cwl-tes) in order to provide the s3 location of the outputs.

This is still work in progress in terms of code cleanup and perhaps better handling of edge cases and more elegant solutions to output capture, but so far has worked well for a number of pipelines in our system.