### PR TITLE
Fix isfile

### DIFF
--- a/cwl_tes/ftp.py
+++ b/cwl_tes/ftp.py
@@ -166,8 +166,10 @@ class FtpFsAccess(StdFsAccess):
         ftp = self._connect(fn)
         if ftp:
             try:
-                self.size(fn)
-                return True
+                if not self.size(fn) is None:
+                    return True
+                else:
+                    return False
             except ftplib.all_errors:
                 return False
         return super(FtpFsAccess, self).isfile(fn)


### PR DESCRIPTION
Current code expects exception to self.size(fn) when fn is Directory.
But when fn is Directory, self.size(fn) returns None.